### PR TITLE
Add waffle.io ready indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Stories in Ready](https://badge.waffle.io/iteratehackerspace/horloge.png?label=ready&title=Ready)](http://waffle.io/iteratehackerspace/horloge)
+
 Horloge is a [Pomodoro](http://cirillocompany.de/pages/pomodoro-technique)-style timer, aiming at improving your work productivity.
 
 ## Core Features


### PR DESCRIPTION
This adds a waffle.io indicator with the number of issues that are ready to be worked on and a link to the waffle board.