### PR TITLE
adjust timer so it won't log '0 minutes left before' finishing #27

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ const horloge = require('commander');
  * Methods
  */
 const runInterval = function (duration = 25, interval = 60 * 1000) {
-  console.log(`${duration}mn left`);
   if (duration === 0) {
     console.log("Time's up");
   } else {
+    console.log(`${duration}mn left`);
     // calls runInterval after interval is elapsed with the updated parameters
     setTimeout(runInterval, interval, duration - 1, interval);
   }


### PR DESCRIPTION
If we put the logging line inside the else block, on the last iteration the function will execute only what's inside the "if" block so we won't get 0 mins left. 